### PR TITLE
Script fails when hostDeployment fails

### DIFF
--- a/Hands-on lab/Resources/SmartHotelHost.json
+++ b/Hands-on lab/Resources/SmartHotelHost.json
@@ -105,7 +105,7 @@
             ],
             "resources": [
                 {
-                    "name": "CustomSciptExtension",
+                    "name": "CustomScriptExtension",
                     "type": "extensions",
                     "apiVersion": "2016-03-30",
                     "location": "[resourceGroup().location]",


### PR DESCRIPTION
This fixes what looks like a typo in the hostDeployment script, which causes the hostDeployment to fail. See attached.
[Deployment-hostDeployment.zip](https://github.com/microsoft/MCW-Line-of-business-application-migration/files/7239100/Deployment-hostDeployment.zip)
 